### PR TITLE
Docker workflow

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,111 @@
+name: Docker
+
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: docker.io
+  # github.repository as <account>/<repo>
+  REGISTRY_IMAGE: <dockerhub_account_name_here>/hdkeygen
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+    steps:
+      -
+        name: Prepare
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: <dockerhub_account_name_here>
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          file: Dockerfile
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      -
+        name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      -
+        name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      -
+        name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+      -
+        name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: <dockerhub_account_name_here>
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      -
+        name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      -
+        name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:alpine as builder
+
+
+WORKDIR /build
+COPY ./ ./
+RUN go mod download
+RUN CGO_ENABLED=0 go build -o ./hdkeygen
+
+
+FROM scratch
+WORKDIR /app
+COPY --from=builder /build/hdkeygen ./hdkeygen
+ENTRYPOINT ["./hdkeygen"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Installation
 $ go install github.com/modood/hdkeygen@latest
 ```
 
+Running in Docker
+-----------------
+For security reasons it's recommended to start a Docker container with disabled networking:
+```
+$ docker run --network none --rm -it <dockerhub_account_name_here>/hdkeygen
+```
+
 Usage
 -----
 


### PR DESCRIPTION
Hello,

It was nice to discover this fast and simple tool for wallet generation! I also like this fair point mentioned in README:

> Can I trust this code?
>  Don't Trust. Verify.
>  We recommend every user of this library audit and verify any underlying code for its validity and suitability.

In order to make the process of key generation even more secure, I think the application might be containerized. Running the app in temporary Docker container with disabled networking would be additional way to ensure that no keys are submitted outside of user's machine by any malicious library / injected code. Here is a pull request which goal is to build AMD and ARM Docker images via Github actions, the same way as you publish binary releases.

I tested this workflow in my repo; the workflow run is here
https://github.com/ignytis/hdkeygen/actions/runs/9569249480
and built image is here:
https://hub.docker.com/r/ignytis/hdkeygen/tags
It's runnable by
```
$ docker run --network none --rm -it ignytis/hdkeygen 
```

However, there will be some actions needed:
- replace the `<dockerhub_account_name_here>` part with your Dockerhub repo name
- Configure the integration with your Dockerhub account

What do you think about this patch? It it's not suitable by any reasons, then no problem, I'll keep it in my branch and Dockerhub account